### PR TITLE
Allows Users to read articles from external news agencies.  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 !/tmp/.keep
 .env
 master.key
+config/secret.yml

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'devise'
 
 
 group :development, :test do
-  gem 'dotenv-rails'
+  gem 'dotenv-rails', require: 'dotenv/rails-now'
   gem 'factory_bot_rails'
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'devise'
 
 
 group :development, :test do
+  gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'devise'
 
 
 group :development, :test do
-  gem 'dotenv-rails', require: 'dotenv/rails-now'
+  gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'pry-byebug'
   gem 'pry-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '2.4.1'
 
 gem 'rails', '~> 5.2.0.rc1'
 gem 'pg', '>= 0.18', '< 2.0'
+gem 'news-api'
 gem 'puma', '~> 3.11'
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,10 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     erubi (1.7.1)
     execjs (2.7.0)
     factory_bot (4.8.2)
@@ -270,6 +274,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner
   devise
+  dotenv-rails
   factory_bot_rails
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,7 @@ GEM
     msgpack (1.2.4)
     multi_json (1.13.1)
     multi_test (0.1.2)
+    news-api (0.0.0)
     nio4r (2.2.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -272,6 +273,7 @@ DEPENDENCIES
   factory_bot_rails
   launchy
   listen (>= 3.0.5, < 3.2)
+  news-api
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,4 +1,7 @@
+require 'news-api'
 class IndexController < ApplicationController
   def index
+    api_key = News.new("e9b2cff169de4096a9d34df4e3742ab2")
+    @api_new_feed = api_key.get_top_headlines(category: 'technology', country: 'us', pageSize: 5)
   end
 end

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,7 +1,7 @@
 require 'news-api'
 class IndexController < ApplicationController
   def index
-    api_key = News.new("e9b2cff169de4096a9d34df4e3742ab2")
+    api_key = News.new(ENV["SECRET_KEY_NEWS_API"])
     @api_new_feed = api_key.get_top_headlines(category: 'technology', country: 'us', pageSize: 5)
   end
 end

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,7 +1,7 @@
 require 'news-api'
 class IndexController < ApplicationController
   def index
-    api_key = News.new(ENV["SECRET_KEY_NEWS_API"])
+    api_key = News.new(SECRET_KEY_NEWS_API)
     @api_new_feed = api_key.get_top_headlines(category: 'technology', country: 'us', pageSize: 5)
   end
 end

--- a/app/controllers/index_controller.rb
+++ b/app/controllers/index_controller.rb
@@ -1,7 +1,7 @@
 require 'news-api'
 class IndexController < ApplicationController
   def index
-    api_key = News.new(SECRET_KEY_NEWS_API)
+    api_key = News.new(ENV['SECRET_KEY_NEWS_API'])
     @api_new_feed = api_key.get_top_headlines(category: 'technology', country: 'us', pageSize: 5)
   end
 end

--- a/app/views/index/index.html.erb
+++ b/app/views/index/index.html.erb
@@ -7,3 +7,11 @@
   <li><%= link_to 'Login', new_user_session_path %></li>
   <li><%= link_to 'Register', new_user_registration_path %></li>
 <% end %>
+
+<% @api_new_feed.each do |article|%>
+<article id="news">
+  <h1><%=article.title %></h1>
+  <p><%=article.description %></p>
+  <%= image_tag(article.urlToImage, size: '150x100', alt: "Source not found") %>
+</article>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ require "sprockets/railtie"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
+Dotenv::Railtie.load
+
 
 module Dreamteam
   class Application < Rails::Application

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,15 @@ module Dreamteam
       generate.controller_specs false
       generate.system_tests false
     end
+
+    config_files = ['secret.yml']
+
+    config_files.each do |file_name|
+      file_path = File.join(Rails.root, 'config', file_name)
+      config_keys = HashWithIndifferentAccess.new(YAML::load(IO.read(file_path)))[Rails.env]
+      config_keys.each do |k,v|
+        ENV[k.upcase] ||= v
+      end
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,15 +29,5 @@ module Dreamteam
       generate.controller_specs false
       generate.system_tests false
     end
-
-    config_files = ['secret.yml']
-
-    config_files.each do |file_name|
-      file_path = File.join(Rails.root, 'config', file_name)
-      config_keys = HashWithIndifferentAccess.new(YAML::load(IO.read(file_path)))[Rails.env]
-      config_keys.each do |k,v|
-        ENV[k.upcase] ||= v
-      end
-    end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,6 +2,7 @@ Rails.application.configure do
   config.cache_classes = false
   config.eager_load = false
   config.consider_all_requests_local = true
+  config.require_master_key = true
 
 
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
@@ -20,7 +21,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  
+
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,7 @@ Rails.application.configure do
 
   # Code is not reloaded between requests.
   config.cache_classes = true
+  config.secret_key_news_api = true
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,7 +3,7 @@ Rails.application.configure do
 
   # Code is not reloaded between requests.
   config.cache_classes = true
-  config.secret_key_news_api = true
+  
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,27 +15,6 @@ ActiveRecord::Schema.define(version: 2018_03_17_192009) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
-  end
-
-  create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
-
   create_table "articles", force: :cascade do |t|
     t.string "title"
     t.text "body"

--- a/features/fetching_articles_from_news_api.feature
+++ b/features/fetching_articles_from_news_api.feature
@@ -6,4 +6,4 @@ Feature: Website should contain news from API
 
 Scenario: User visit the Index page
   Given I am on the "Index" page
-  Then I should see 5 "News"
+  Then I should see 5 articles

--- a/features/fetching_articles_from_news_api.feature
+++ b/features/fetching_articles_from_news_api.feature
@@ -1,0 +1,9 @@
+Feature: Website should contain news from API
+  As a dev team
+  In order to provide more articles for users to read
+  We would like to pull articles from other sources using an API
+
+
+Scenario: User visit the Index page
+  Given I am on the "Index" page
+  Then I should see 5 "News"

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -28,8 +28,8 @@ Then("I should see {string}") do |message|
   expect(page).to have_content message
 end
 
-Then("I should see {int} {string}") do |int, news_api|
-  expect(page).to have_css "news", count: int
+Then("I should see {int} articles") do |int|
+  expect(page).to have_css "article", count: int
 end
 
 Then("show me the page") do

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -28,6 +28,10 @@ Then("I should see {string}") do |message|
   expect(page).to have_content message
 end
 
+Then("I should see {int} {string}") do |int, news_api|
+  expect(page).to have_css "news", count: int
+end
+
 Then("show me the page") do
   save_and_open_page
 end

--- a/features/user_can_submit_article_for_review.feature
+++ b/features/user_can_submit_article_for_review.feature
@@ -1,0 +1,4 @@
+Feature: User should be able to sumbit article for review
+  As a journalist
+  In order to be able to get my articles published
+  I would like to be able to submit the articles for review


### PR DESCRIPTION
#### PT Story: https://www.pivotaltracker.com/story/show/155901294
#### Description
* Unfortunately we had to duplicate another PR due to system errors. We ran into an error that said some unknown coffee script files couldn't be found even though we didn't add or write anything related to coffee script. The error was only on one local repo but the other pairing partner couldn't run the code either because of SSL certificate issues, so we had to re-clone the entire repo locally. We decided to revert a couple of commits and make it work from there.

Changes proposed in this pull request:
* Displays news articles from various external sources

### What I have learned working on this feature:

* How to test fetching from an API
* How to use News-api
* How to work with CI and secret files

### Screenshots 
<img width="1251" alt="screen shot 2018-03-18 at 13 16 59" src="https://user-images.githubusercontent.com/11982117/37590132-9aa67fc2-2b67-11e8-874c-acfe8d8e6509.png">
